### PR TITLE
Updated BigDecimal unmarshalling

### DIFF
--- a/lib/angus/unmarshalling.rb
+++ b/lib/angus/unmarshalling.rb
@@ -22,9 +22,9 @@ module Angus
         DateTime.iso8601(scalar)
       when :decimal
         begin
-          BigDecimal.new(scalar) # Para Ruby < 2.6
-        rescue TypeError, ArgumentError, NoMethodError
-          BigDecimal(scalar) # Para Ruby 2.6+, JRuby
+          BigDecimal(scalar) # Para Ruby 2.4+, JRuby
+        rescue NoMethodError
+          BigDecimal.new(scalar) # Para Ruby < 2.4
         end
       when :object
         scalar

--- a/lib/angus/unmarshalling.rb
+++ b/lib/angus/unmarshalling.rb
@@ -21,10 +21,10 @@ module Angus
       when :date_time
         DateTime.iso8601(scalar)
       when :decimal
-        if BigDecimal.respond_to?(:new)
+        begin
           BigDecimal.new(scalar) # Para Ruby < 2.6
-        else
-          BigDecimal(scalar) # Para Ruby 2.6+
+        rescue TypeError, ArgumentError, NoMethodError
+          BigDecimal(scalar) # Para Ruby 2.6+, JRuby
         end
       when :object
         scalar


### PR DESCRIPTION
There's a situation in JRuby 10 in which `BigDecimal#new` is defined but it's not implemented, returning an error.

Testing the old code in Ruby it works fine, while JRuby fails with a `TypeError`.

 ```ruby
 # RUBY_ENGINE == 'ruby'
 BigDecimal.respond_to? :new
 #=> false
 defined? BigDecimal.new
 #=> nil
 
 if BigDecimal.respond_to? :new
   BigDecimal.new(scalar) #skips this
 else
   BigDecimal(scalar) # goes here
 end

#---

# RUBY_ENGINE == 'jruby'
BigDecimal.respond_to? :new
#=> true
defined? BigDecimal.new
#=> 'method'

 if BigDecimal.respond_to? :new
   BigDecimal.new(scalar) #=> TypeError: allocator undefined for BigDecimal
 else
   BigDecimal(scalar)
 end
 ```

The proposed solution defaults to use `Kernel#BigDecimal` and uses a `begin-rescue` to intercept if the method doesn't exists and uses the `BigDecimal#new` method then, thus solving the problem with the method defined but not implemented and keeping compatibility with older Ruby versions.

```ruby
begin
  BigDecimal(scalar)
rescue NoMethodError
  BigDecimal.new(scalar)
end
```